### PR TITLE
Fix Webpacker configuration

### DIFF
--- a/config/webpacker.yml
+++ b/config/webpacker.yml
@@ -17,7 +17,7 @@ default: &default
   cache_manifest: false
 
   # Extract and emit a css file
-  extract_css: false
+  extract_css: true
 
   static_assets_extensions:
     - .jpg
@@ -88,7 +88,7 @@ production:
   <<: *default
 
   # Production depends on precompilation of packs prior to booting for performance.
-  compile: false
+  compile: true
 
   # Extract and emit a css file
   extract_css: true


### PR DESCRIPTION
### What does this PR do?
- Configures Webpacker to extract CSS from `application.scss` and precompile assets in production

### How should this be manually tested?
- By navigating to `total-being-reset.herokuapp.com` and making sure the home (`/`), about (`/about`), and contact (`/contact`) pages are appearing correctly
- Also check that navigation between pages with the navbar works correctly

### What are the relevant tickets?
- #2 Deploy to Heroku

### Thoughts/Refactors
- None

